### PR TITLE
Add integration test for session creation

### DIFF
--- a/tests/test_session_open.sh
+++ b/tests/test_session_open.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB=pg_browser_test
+
+sudo -u postgres dropdb --if-exists "$DB"
+sudo -u postgres createdb "$DB"
+
+sudo -u postgres psql -d "$DB" -v ON_ERROR_STOP=1 -f sql/00_install.sql
+sudo -u postgres psql -d "$DB" -v ON_ERROR_STOP=1 -f sql/60_pgb_session.sql
+
+SESSION_ID=$(sudo -u postgres psql -d "$DB" -t -A -c "SELECT pgb_session.open('pgb://local/demo');")
+
+if [[ ! "$SESSION_ID" =~ ^[0-9a-f-]{36}$ ]]; then
+  echo "open() returned invalid uuid: $SESSION_ID"
+  exit 1
+fi
+
+URL=$(sudo -u postgres psql -d "$DB" -t -A -c "SELECT current_url FROM pgb_session.session WHERE id = '$SESSION_ID';")
+if [[ "$URL" != "pgb://local/demo" ]]; then
+  echo "unexpected current_url: $URL"
+  exit 1
+fi
+
+COUNT=$(sudo -u postgres psql -d "$DB" -t -A -c "SELECT count(*) FROM pgb_session.history WHERE session_id = '$SESSION_ID' AND n = 1 AND url = 'pgb://local/demo';")
+if [[ "$COUNT" -ne 1 ]]; then
+  echo "history row missing"
+  exit 1
+fi
+
+echo "session_open integration test passed"


### PR DESCRIPTION
## Summary
- add bash integration test verifying `pgb_session.open` creates session and history rows

## Testing
- `./tests/test_session_open.sh`


------
https://chatgpt.com/codex/tasks/task_e_6890d71b0c048328bf068266c0c473ac