### PR TITLE
Add unit test for session creation

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+sudo -u postgres psql -v ON_ERROR_STOP=1 -f "$(dirname "$0")/test_pgb_session.sql" -d postgres

--- a/tests/test_pgb_session.sql
+++ b/tests/test_pgb_session.sql
@@ -1,0 +1,32 @@
+\set ON_ERROR_STOP on
+
+BEGIN;
+\i sql/00_install.sql
+\i sql/60_pgb_session.sql
+
+DO $$
+DECLARE
+    sid UUID;
+BEGIN
+    sid := pgb_session.open('pgb://local/demo');
+    IF sid IS NULL THEN
+        RAISE EXCEPTION 'pgb_session.open returned NULL';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pgb_session.session
+        WHERE id = sid AND current_url = 'pgb://local/demo'
+    ) THEN
+        RAISE EXCEPTION 'session row missing or incorrect';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pgb_session.history
+        WHERE session_id = sid AND n = 1 AND url = 'pgb://local/demo'
+    ) THEN
+        RAISE EXCEPTION 'history row missing or incorrect';
+    END IF;
+END;
+$$;
+
+ROLLBACK;


### PR DESCRIPTION
## Summary
- add SQL-based unit test for `pgb_session.open`
- provide helper script for running tests

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_6890d70d944c83289d139589662c6312