### PR TITLE
Add CI and CD workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,20 @@
+---
+name: CD
+
+'on':
+  push:
+    tags: ['v*']
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create archive
+        run: tar czf pg_browser_sql.tar.gz sql
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: pg_browser_sql.tar.gz
+          draft: false
+          prerelease: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+---
+name: CI
+
+'on':
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: pg_browser_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install psql client
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+      - name: Run schema scripts
+        env:
+          PGPASSWORD: postgres
+        run: |
+          for file in sql/00_install.sql sql/60_pgb_session.sql; do
+            psql -h localhost -U postgres -d pg_browser_test -f "$file"
+          done

--- a/README.md
+++ b/README.md
@@ -199,6 +199,13 @@ docs/
 
 ---
 
+## CI/CD
+
+Automated GitHub Actions run PostgreSQL schema checks on every push and package
+SQL files into a release archive when tags matching `v*` are created.
+
+---
+
 ## License
 
 TBD. (Suggest: permissive OSS like MIT/Apache-2.0.)


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run PostgreSQL schema scripts for CI
- package SQL files into a release artifact on version tags
- document new CI/CD workflows in README

## Testing
- `yamllint .github/workflows/ci.yml .github/workflows/cd.yml`
- `sudo -u postgres psql -v ON_ERROR_STOP=1 -f sql/00_install.sql`
- `sudo -u postgres psql -v ON_ERROR_STOP=1 -f sql/60_pgb_session.sql`


------
https://chatgpt.com/codex/tasks/task_e_6890d703b1648328a8d5fbb0378a9753