### PR TITLE
Add regression test bed

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,14 @@ docs/
 
 ---
 
+## Testing
+
+A minimal regression harness lives under `test/`. Run `test/run.sh` to execute
+the pg_regress test suite (requires a local PostgreSQL server accessible as the
+`postgres` superuser).
+
+---
+
 ## Contributing
 
 - File issues for design/API changes before implementation.

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/test/expected/session.out
+++ b/test/expected/session.out
@@ -1,0 +1,55 @@
+-- Install core dependencies
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE SCHEMA IF NOT EXISTS pgb_session;
+CREATE TABLE IF NOT EXISTS pgb_session.session (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    current_url TEXT NOT NULL,
+    state JSONB NOT NULL DEFAULT '{}'::jsonb,
+    focus UUID
+);
+CREATE TABLE IF NOT EXISTS pgb_session.history (
+    session_id UUID NOT NULL REFERENCES pgb_session.session(id) ON DELETE CASCADE,
+    n INT NOT NULL,
+    url TEXT NOT NULL,
+    ts TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY(session_id, n)
+);
+CREATE OR REPLACE FUNCTION pgb_session.open(p_url TEXT)
+RETURNS UUID
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    sid UUID;
+BEGIN
+    INSERT INTO pgb_session.session(current_url)
+    VALUES (p_url)
+    RETURNING id INTO sid;
+
+    INSERT INTO pgb_session.history(session_id, n, url)
+    VALUES (sid, 1, p_url);
+
+    RETURN sid;
+END;
+$$;
+-- Open a new session and ensure an ID is returned
+SELECT pgb_session.open('pgb://local/demo') IS NOT NULL AS opened;
+ opened 
+--------
+ t
+(1 row)
+
+-- Verify session table has one row
+SELECT count(*) AS session_count FROM pgb_session.session;
+ session_count 
+---------------
+             1
+(1 row)
+
+-- Verify history table has one entry
+SELECT count(*) AS history_count FROM pgb_session.history;
+ history_count 
+---------------
+             1
+(1 row)
+

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run regression tests using pg_regress. Requires a running PostgreSQL server
+# accessible via local Unix socket and the `postgres` superuser.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUTPUT_DIR="$SCRIPT_DIR/results"
+mkdir -p "$OUTPUT_DIR"
+chown postgres:postgres "$OUTPUT_DIR"
+
+su postgres -c "/usr/lib/postgresql/16/lib/pgxs/src/test/regress/pg_regress --inputdir=$SCRIPT_DIR --outputdir=$OUTPUT_DIR --expecteddir=$SCRIPT_DIR/expected session"

--- a/test/sql/session.sql
+++ b/test/sql/session.sql
@@ -1,0 +1,47 @@
+-- Install core dependencies
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE SCHEMA IF NOT EXISTS pgb_session;
+
+CREATE TABLE IF NOT EXISTS pgb_session.session (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    current_url TEXT NOT NULL,
+    state JSONB NOT NULL DEFAULT '{}'::jsonb,
+    focus UUID
+);
+
+CREATE TABLE IF NOT EXISTS pgb_session.history (
+    session_id UUID NOT NULL REFERENCES pgb_session.session(id) ON DELETE CASCADE,
+    n INT NOT NULL,
+    url TEXT NOT NULL,
+    ts TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY(session_id, n)
+);
+
+CREATE OR REPLACE FUNCTION pgb_session.open(p_url TEXT)
+RETURNS UUID
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    sid UUID;
+BEGIN
+    INSERT INTO pgb_session.session(current_url)
+    VALUES (p_url)
+    RETURNING id INTO sid;
+
+    INSERT INTO pgb_session.history(session_id, n, url)
+    VALUES (sid, 1, p_url);
+
+    RETURN sid;
+END;
+$$;
+
+-- Open a new session and ensure an ID is returned
+SELECT pgb_session.open('pgb://local/demo') IS NOT NULL AS opened;
+
+-- Verify session table has one row
+SELECT count(*) AS session_count FROM pgb_session.session;
+
+-- Verify history table has one entry
+SELECT count(*) AS history_count FROM pgb_session.history;


### PR DESCRIPTION
## Summary
- document test harness in README
- add run script for regression tests
- create baseline session regression test

## Testing
- `./test/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_6890d71338fc8328921329f5e8159338