### PR TITLE
Use pg_config for pg_regress path

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,10 @@ docs/
 
 A minimal regression harness lives under `tests/`. Run `tests/run_regress.sh` to
 execute the pg_regress test suite (requires a local PostgreSQL server
-accessible as the `postgres` superuser). Additional integration tests live in
-the same directory.
+accessible as the `postgres` superuser). The script uses `pg_config` to locate
+`pg_regress`; install the PostgreSQL development package (e.g.,
+`postgresql-server-dev-16` on Debian/Ubuntu) if `pg_config` is not available.
+Additional integration tests live in the same directory.
 
 ---
 

--- a/tests/run_regress.sh
+++ b/tests/run_regress.sh
@@ -4,9 +4,16 @@ set -euo pipefail
 # Run regression tests using pg_regress. Requires a running PostgreSQL server
 # accessible via local Unix socket and the `postgres` superuser.
 
+if ! command -v pg_config >/dev/null; then
+  echo "pg_config not found. Install PostgreSQL development packages to run tests." >&2
+  exit 1
+fi
+
+PG_REGRESS="$(pg_config --bindir)/pg_regress"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OUTPUT_DIR="$SCRIPT_DIR/results"
 mkdir -p "$OUTPUT_DIR"
 chown postgres:postgres "$OUTPUT_DIR"
 
-su postgres -c "/usr/lib/postgresql/16/lib/pgxs/src/test/regress/pg_regress --inputdir=$SCRIPT_DIR --outputdir=$OUTPUT_DIR --expecteddir=$SCRIPT_DIR/expected session"
+su postgres -c "$PG_REGRESS --inputdir=$SCRIPT_DIR --outputdir=$OUTPUT_DIR --expecteddir=$SCRIPT_DIR/expected session"


### PR DESCRIPTION
## Summary
- Run regression tests with pg_regress discovered via `pg_config`
- Document `pg_config` requirement for running tests

## Testing
- `bash tests/run_regress.sh` *(fails: chown: invalid user 'postgres:postgres')*


------
https://chatgpt.com/codex/tasks/task_e_6890e931c34c83289a4eab7ae285f463