### PR TITLE
docs: document session functions

### DIFF
--- a/sql/60_pgb_session.sql
+++ b/sql/60_pgb_session.sql
@@ -34,6 +34,9 @@ BEGIN
 END;
 $$;
 
+COMMENT ON FUNCTION pgb_session.open(p_url TEXT) IS
+    'Open a new session. Parameters: p_url - initial URL. Returns: session UUID.';
+
 CREATE OR REPLACE FUNCTION pgb_session.reload(p_session_id UUID)
 RETURNS VOID
 LANGUAGE plpgsql
@@ -59,3 +62,6 @@ BEGIN
     VALUES (p_session_id, next_n, v_url);
 END;
 $$;
+
+COMMENT ON FUNCTION pgb_session.reload(p_session_id UUID) IS
+    'Record a reload event. Parameters: p_session_id - session ID. Returns: void.';

--- a/tests/expected/session.out
+++ b/tests/expected/session.out
@@ -32,6 +32,8 @@ BEGIN
     RETURN sid;
 END;
 $$;
+COMMENT ON FUNCTION pgb_session.open(p_url TEXT) IS
+    'Open a new session. Parameters: p_url - initial URL. Returns: session UUID.';
 CREATE OR REPLACE FUNCTION pgb_session.reload(p_session_id UUID)
 RETURNS VOID
 LANGUAGE plpgsql
@@ -57,6 +59,8 @@ BEGIN
     VALUES (p_session_id, next_n, v_url);
 END;
 $$;
+COMMENT ON FUNCTION pgb_session.reload(p_session_id UUID) IS
+    'Record a reload event. Parameters: p_session_id - session ID. Returns: void.';
 -- Open a new session and capture the ID
 SELECT pgb_session.open('pgb://local/demo') AS sid \gset
 -- Ensure an ID is returned

--- a/tests/sql/session.sql
+++ b/tests/sql/session.sql
@@ -37,6 +37,9 @@ BEGIN
 END;
 $$;
 
+COMMENT ON FUNCTION pgb_session.open(p_url TEXT) IS
+    'Open a new session. Parameters: p_url - initial URL. Returns: session UUID.';
+
 CREATE OR REPLACE FUNCTION pgb_session.reload(p_session_id UUID)
 RETURNS VOID
 LANGUAGE plpgsql
@@ -62,6 +65,9 @@ BEGIN
     VALUES (p_session_id, next_n, v_url);
 END;
 $$;
+
+COMMENT ON FUNCTION pgb_session.reload(p_session_id UUID) IS
+    'Record a reload event. Parameters: p_session_id - session ID. Returns: void.';
 
 
 -- Open a new session and capture the ID


### PR DESCRIPTION
## Summary
- document purpose and return values for `pgb_session.open` and `pgb_session.reload`
- mirror function comments in regression tests

## Testing
- `./tests/run.sh` *(fails: sudo: unknown user postgres)*
- `bash tests/run_regress.sh` *(fails: chown: invalid user: ‘postgres:postgres’)*

------
https://chatgpt.com/codex/tasks/task_e_6890e92f06f483289317516fedd5e583