### PR TITLE
Validate non-empty URLs in session open

### DIFF
--- a/sql/60_pgb_session.sql
+++ b/sql/60_pgb_session.sql
@@ -23,6 +23,10 @@ AS $$
 DECLARE
     sid UUID;
 BEGIN
+    IF p_url IS NULL OR p_url = '' THEN
+        RAISE EXCEPTION 'url must not be empty';
+    END IF;
+
     INSERT INTO pgb_session.session(current_url)
     VALUES (p_url)
     RETURNING id INTO sid;

--- a/tests/expected/session.out
+++ b/tests/expected/session.out
@@ -22,6 +22,10 @@ AS $$
 DECLARE
     sid UUID;
 BEGIN
+    IF p_url IS NULL OR p_url = '' THEN
+        RAISE EXCEPTION 'url must not be empty';
+    END IF;
+
     INSERT INTO pgb_session.session(current_url)
     VALUES (p_url)
     RETURNING id INTO sid;
@@ -61,15 +65,15 @@ $$;
 SELECT pgb_session.open('pgb://local/demo') AS sid \gset
 -- Ensure an ID is returned
 SELECT :'sid' IS NOT NULL AS opened;
- opened
+ opened 
 --------
  t
 (1 row)
 
 -- Reload the session
 SELECT pgb_session.reload(:'sid');
- pgb_session.reload 
----------------------
+ reload 
+--------
  
 (1 row)
 
@@ -86,3 +90,8 @@ SELECT count(*) AS history_count FROM pgb_session.history;
 ---------------
              2
 (1 row)
+
+-- Ensure empty URL raises an exception
+SELECT pgb_session.open('');
+ERROR:  url must not be empty
+CONTEXT:  PL/pgSQL function pgb_session.open(text) line 6 at RAISE

--- a/tests/sql/session.sql
+++ b/tests/sql/session.sql
@@ -26,6 +26,10 @@ AS $$
 DECLARE
     sid UUID;
 BEGIN
+    IF p_url IS NULL OR p_url = '' THEN
+        RAISE EXCEPTION 'url must not be empty';
+    END IF;
+
     INSERT INTO pgb_session.session(current_url)
     VALUES (p_url)
     RETURNING id INTO sid;
@@ -78,3 +82,6 @@ SELECT count(*) AS session_count FROM pgb_session.session;
 
 -- Verify history table has two entries
 SELECT count(*) AS history_count FROM pgb_session.history;
+
+-- Ensure empty URL raises an exception
+SELECT pgb_session.open('');


### PR DESCRIPTION
## Summary
- ensure `pgb_session.open` rejects NULL or empty URLs
- add regression test verifying empty URLs raise an exception

## Testing
- `bash tests/run.sh`
- `bash tests/run_regress.sh`


------
https://chatgpt.com/codex/tasks/task_e_6890e93015548328b7d7ae3c21f7e4ce