### PR TITLE
Add regression test for invalid session reload

### DIFF
--- a/tests/expected/reload_invalid.out
+++ b/tests/expected/reload_invalid.out
@@ -1,0 +1,12 @@
+-- Attempt to reload a non-existent session; should raise an error
+DO $$
+BEGIN
+    BEGIN
+        PERFORM pgb_session.reload(gen_random_uuid());
+        RAISE EXCEPTION 'reload did not fail';
+    EXCEPTION WHEN others THEN
+        RAISE NOTICE 'error raised as expected';
+    END;
+END;
+$$;
+NOTICE:  error raised as expected

--- a/tests/expected/session.out
+++ b/tests/expected/session.out
@@ -61,15 +61,15 @@ $$;
 SELECT pgb_session.open('pgb://local/demo') AS sid \gset
 -- Ensure an ID is returned
 SELECT :'sid' IS NOT NULL AS opened;
- opened
+ opened 
 --------
  t
 (1 row)
 
 -- Reload the session
 SELECT pgb_session.reload(:'sid');
- pgb_session.reload 
----------------------
+ reload 
+--------
  
 (1 row)
 
@@ -86,3 +86,4 @@ SELECT count(*) AS history_count FROM pgb_session.history;
 ---------------
              2
 (1 row)
+

--- a/tests/run_regress.sh
+++ b/tests/run_regress.sh
@@ -9,4 +9,4 @@ OUTPUT_DIR="$SCRIPT_DIR/results"
 mkdir -p "$OUTPUT_DIR"
 chown postgres:postgres "$OUTPUT_DIR"
 
-su postgres -c "/usr/lib/postgresql/16/lib/pgxs/src/test/regress/pg_regress --inputdir=$SCRIPT_DIR --outputdir=$OUTPUT_DIR --expecteddir=$SCRIPT_DIR/expected session"
+su postgres -c "/usr/lib/postgresql/16/lib/pgxs/src/test/regress/pg_regress --inputdir=$SCRIPT_DIR --outputdir=$OUTPUT_DIR --expecteddir=$SCRIPT_DIR/expected session reload_invalid"

--- a/tests/sql/reload_invalid.sql
+++ b/tests/sql/reload_invalid.sql
@@ -1,0 +1,11 @@
+-- Attempt to reload a non-existent session; should raise an error
+DO $$
+BEGIN
+    BEGIN
+        PERFORM pgb_session.reload(gen_random_uuid());
+        RAISE EXCEPTION 'reload did not fail';
+    EXCEPTION WHEN others THEN
+        RAISE NOTICE 'error raised as expected';
+    END;
+END;
+$$;


### PR DESCRIPTION
## Summary
- add regression SQL that ensures `pgb_session.reload(gen_random_uuid())` raises an error
- provide expected output for the new test and include it in the regression runner
- sync existing `session` expected output with current Postgres output

## Testing
- `bash tests/run_regress.sh`


------
https://chatgpt.com/codex/tasks/task_e_6890e92e564c8328a2e063ede9c6523a