### PR TITLE
Use PG_REGRESS variable in regression script

### DIFF
--- a/tests/run_regress.sh
+++ b/tests/run_regress.sh
@@ -16,4 +16,4 @@ OUTPUT_DIR="$SCRIPT_DIR/results"
 mkdir -p "$OUTPUT_DIR"
 chown postgres:postgres "$OUTPUT_DIR"
 
-su postgres -c "/usr/lib/postgresql/16/lib/pgxs/src/test/regress/pg_regress --inputdir=$SCRIPT_DIR --outputdir=$OUTPUT_DIR --expecteddir=$SCRIPT_DIR/expected session reload_invalid"
+su postgres -c "$PG_REGRESS --inputdir=$SCRIPT_DIR --outputdir=$OUTPUT_DIR --expecteddir=$SCRIPT_DIR/expected session reload_invalid"


### PR DESCRIPTION
## Summary
- call pg_regress via the PG_REGRESS variable instead of a hard-coded path

## Testing
- `bash tests/run_regress.sh` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689117cfd08483289c2e5d9dc345fafb