### PR TITLE
Ensure session reload sequence is concurrency-safe

### DIFF
--- a/sql/60_pgb_session.sql
+++ b/sql/60_pgb_session.sql
@@ -51,7 +51,8 @@ DECLARE
 BEGIN
     SELECT current_url INTO v_url
     FROM pgb_session.session
-    WHERE id = p_session_id;
+    WHERE id = p_session_id
+    FOR UPDATE;
 
     IF v_url IS NULL THEN
         RAISE EXCEPTION 'session % not found', p_session_id;

--- a/tests/expected/reload_concurrent.out
+++ b/tests/expected/reload_concurrent.out
@@ -1,0 +1,62 @@
+-- Test concurrent reloads to ensure unique history entries
+CREATE EXTENSION IF NOT EXISTS dblink;
+-- Open a new session and capture the ID
+SELECT pgb_session.open('pgb://local/demo') AS sid \gset
+-- Establish two connections for concurrent reloads
+SELECT dblink_connect('c1', 'dbname=' || current_database());
+ dblink_connect 
+----------------
+ OK
+(1 row)
+
+SELECT dblink_connect('c2', 'dbname=' || current_database());
+ dblink_connect 
+----------------
+ OK
+(1 row)
+
+-- Launch reloads concurrently
+SELECT dblink_send_query('c1', format('SELECT pgb_session.reload(''%s'')', :'sid'));
+ dblink_send_query 
+-------------------
+                 1
+(1 row)
+
+SELECT dblink_send_query('c2', format('SELECT pgb_session.reload(''%s'')', :'sid'));
+ dblink_send_query 
+-------------------
+                 1
+(1 row)
+
+-- Wait for both reloads to complete
+SELECT * FROM dblink_get_result('c1') AS t(result text);
+ result 
+--------
+ 
+(1 row)
+
+SELECT * FROM dblink_get_result('c2') AS t(result text);
+ result 
+--------
+ 
+(1 row)
+
+-- Verify history sequence numbers are unique and sequential
+SELECT array_agg(n ORDER BY n) AS ns FROM pgb_session.history WHERE session_id = :'sid';
+   ns    
+---------
+ {1,2,3}
+(1 row)
+
+SELECT dblink_disconnect('c1');
+ dblink_disconnect 
+-------------------
+ OK
+(1 row)
+
+SELECT dblink_disconnect('c2');
+ dblink_disconnect 
+-------------------
+ OK
+(1 row)
+

--- a/tests/expected/session.out
+++ b/tests/expected/session.out
@@ -1,10 +1,8 @@
 -- Install core dependencies
 \ir ../../sql/00_install.sql
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
-CREATE EXTENSION
 \ir ../../sql/60_pgb_session.sql
 CREATE SCHEMA IF NOT EXISTS pgb_session;
-CREATE SCHEMA
 CREATE TABLE IF NOT EXISTS pgb_session.session (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -12,7 +10,6 @@ CREATE TABLE IF NOT EXISTS pgb_session.session (
     state JSONB NOT NULL DEFAULT '{}'::jsonb,
     focus UUID
 );
-CREATE TABLE
 CREATE TABLE IF NOT EXISTS pgb_session.history (
     session_id UUID NOT NULL REFERENCES pgb_session.session(id) ON DELETE CASCADE,
     n INT NOT NULL,
@@ -20,7 +17,6 @@ CREATE TABLE IF NOT EXISTS pgb_session.history (
     ts TIMESTAMPTZ NOT NULL DEFAULT now(),
     PRIMARY KEY(session_id, n)
 );
-CREATE TABLE
 CREATE OR REPLACE FUNCTION pgb_session.open(p_url TEXT)
 RETURNS UUID
 LANGUAGE plpgsql
@@ -42,12 +38,8 @@ BEGIN
     RETURN sid;
 END;
 $$;
-
-CREATE FUNCTION
-
 COMMENT ON FUNCTION pgb_session.open(p_url TEXT) IS
     'Open a new session. Parameters: p_url - initial URL. Returns: session UUID.';
-
 CREATE OR REPLACE FUNCTION pgb_session.reload(p_session_id UUID)
 RETURNS VOID
 LANGUAGE plpgsql
@@ -58,7 +50,8 @@ DECLARE
 BEGIN
     SELECT current_url INTO v_url
     FROM pgb_session.session
-    WHERE id = p_session_id;
+    WHERE id = p_session_id
+    FOR UPDATE;
 
     IF v_url IS NULL THEN
         RAISE EXCEPTION 'session % not found', p_session_id;
@@ -73,12 +66,8 @@ BEGIN
     VALUES (p_session_id, next_n, v_url);
 END;
 $$;
-
-CREATE FUNCTION
-
 COMMENT ON FUNCTION pgb_session.reload(p_session_id UUID) IS
     'Record a reload event. Parameters: p_session_id - session ID. Returns: void.';
-
 -- Open a new session and capture the ID
 SELECT pgb_session.open('pgb://local/demo') AS sid \gset
 -- Ensure an ID is returned
@@ -90,23 +79,21 @@ SELECT :'sid' IS NOT NULL AS opened;
 
 -- Reload the session
 SELECT pgb_session.reload(:'sid');
-
  reload 
-
 --------
  
 (1 row)
 
 -- Verify session table has one row
 SELECT count(*) AS session_count FROM pgb_session.session;
- session_count
+ session_count 
 ---------------
              1
 (1 row)
 
 -- Verify history table has two entries
 SELECT count(*) AS history_count FROM pgb_session.history;
- history_count
+ history_count 
 ---------------
              2
 (1 row)

--- a/tests/run_regress.sh
+++ b/tests/run_regress.sh
@@ -16,4 +16,4 @@ OUTPUT_DIR="$SCRIPT_DIR/results"
 mkdir -p "$OUTPUT_DIR"
 chown postgres:postgres "$OUTPUT_DIR"
 
-su postgres -c "/usr/lib/postgresql/16/lib/pgxs/src/test/regress/pg_regress --inputdir=$SCRIPT_DIR --outputdir=$OUTPUT_DIR --expecteddir=$SCRIPT_DIR/expected session reload_invalid"
+su postgres -c "cd $SCRIPT_DIR/sql && /usr/lib/postgresql/16/lib/pgxs/src/test/regress/pg_regress --inputdir=$SCRIPT_DIR --outputdir=$OUTPUT_DIR --expecteddir=$SCRIPT_DIR/expected session reload_invalid reload_concurrent"

--- a/tests/sql/reload_concurrent.sql
+++ b/tests/sql/reload_concurrent.sql
@@ -1,0 +1,23 @@
+-- Test concurrent reloads to ensure unique history entries
+CREATE EXTENSION IF NOT EXISTS dblink;
+
+-- Open a new session and capture the ID
+SELECT pgb_session.open('pgb://local/demo') AS sid \gset
+
+-- Establish two connections for concurrent reloads
+SELECT dblink_connect('c1', 'dbname=' || current_database());
+SELECT dblink_connect('c2', 'dbname=' || current_database());
+
+-- Launch reloads concurrently
+SELECT dblink_send_query('c1', format('SELECT pgb_session.reload(''%s'')', :'sid'));
+SELECT dblink_send_query('c2', format('SELECT pgb_session.reload(''%s'')', :'sid'));
+
+-- Wait for both reloads to complete
+SELECT * FROM dblink_get_result('c1') AS t(result text);
+SELECT * FROM dblink_get_result('c2') AS t(result text);
+
+-- Verify history sequence numbers are unique and sequential
+SELECT array_agg(n ORDER BY n) AS ns FROM pgb_session.history WHERE session_id = :'sid';
+
+SELECT dblink_disconnect('c1');
+SELECT dblink_disconnect('c2');


### PR DESCRIPTION
## Summary
- guard session reload with a row-level lock and compute next history index safely
- add regression test exercising concurrent reload calls

## Testing
- `tests/run.sh`
- `tests/run_regress.sh`


------
https://chatgpt.com/codex/tasks/task_e_689117cec46883288f8464905bc20c81