### PR TITLE
Validate URL schemes when opening sessions

### DIFF
--- a/sql/60_pgb_session.sql
+++ b/sql/60_pgb_session.sql
@@ -27,6 +27,10 @@ BEGIN
         RAISE EXCEPTION 'url must not be empty';
     END IF;
 
+    IF p_url !~ '^(pgb|https?)://' THEN
+        RAISE EXCEPTION 'unsupported URL scheme: %', p_url;
+    END IF;
+
     INSERT INTO pgb_session.session(current_url)
     VALUES (p_url)
     RETURNING id INTO sid;

--- a/tests/expected/session.out
+++ b/tests/expected/session.out
@@ -32,6 +32,10 @@ BEGIN
         RAISE EXCEPTION 'url must not be empty';
     END IF;
 
+    IF p_url !~ '^(pgb|https?)://' THEN
+        RAISE EXCEPTION 'unsupported URL scheme: %', p_url;
+    END IF;
+
     INSERT INTO pgb_session.session(current_url)
     VALUES (p_url)
     RETURNING id INTO sid;
@@ -42,12 +46,10 @@ BEGIN
     RETURN sid;
 END;
 $$;
-
 CREATE FUNCTION
-
 COMMENT ON FUNCTION pgb_session.open(p_url TEXT) IS
     'Open a new session. Parameters: p_url - initial URL. Returns: session UUID.';
-
+COMMENT
 CREATE OR REPLACE FUNCTION pgb_session.reload(p_session_id UUID)
 RETURNS VOID
 LANGUAGE plpgsql
@@ -73,12 +75,10 @@ BEGIN
     VALUES (p_session_id, next_n, v_url);
 END;
 $$;
-
 CREATE FUNCTION
-
 COMMENT ON FUNCTION pgb_session.reload(p_session_id UUID) IS
     'Record a reload event. Parameters: p_session_id - session ID. Returns: void.';
-
+COMMENT
 -- Open a new session and capture the ID
 SELECT pgb_session.open('pgb://local/demo') AS sid \gset
 -- Ensure an ID is returned
@@ -90,28 +90,43 @@ SELECT :'sid' IS NOT NULL AS opened;
 
 -- Reload the session
 SELECT pgb_session.reload(:'sid');
-
  reload 
-
 --------
  
 (1 row)
 
 -- Verify session table has one row
 SELECT count(*) AS session_count FROM pgb_session.session;
- session_count
+ session_count 
 ---------------
              1
 (1 row)
 
 -- Verify history table has two entries
 SELECT count(*) AS history_count FROM pgb_session.history;
- history_count
+ history_count 
 ---------------
              2
 (1 row)
 
+-- Accept valid URL schemes
+SELECT pgb_session.open('http://example.com') IS NOT NULL AS http_opened;
+ http_opened 
+-------------
+ t
+(1 row)
+
+SELECT pgb_session.open('https://example.com') IS NOT NULL AS https_opened;
+ https_opened 
+--------------
+ t
+(1 row)
+
+-- Reject invalid URL scheme
+SELECT pgb_session.open('ftp://example.com');
+psql:session.sql:25: ERROR:  unsupported URL scheme: ftp://example.com
+CONTEXT:  PL/pgSQL function pgb_session.open(text) line 10 at RAISE
 -- Ensure empty URL raises an exception
 SELECT pgb_session.open('');
-ERROR:  url must not be empty
+psql:session.sql:28: ERROR:  url must not be empty
 CONTEXT:  PL/pgSQL function pgb_session.open(text) line 6 at RAISE

--- a/tests/sql/session.sql
+++ b/tests/sql/session.sql
@@ -17,5 +17,12 @@ SELECT count(*) AS session_count FROM pgb_session.session;
 -- Verify history table has two entries
 SELECT count(*) AS history_count FROM pgb_session.history;
 
+-- Accept valid URL schemes
+SELECT pgb_session.open('http://example.com') IS NOT NULL AS http_opened;
+SELECT pgb_session.open('https://example.com') IS NOT NULL AS https_opened;
+
+-- Reject invalid URL scheme
+SELECT pgb_session.open('ftp://example.com');
+
 -- Ensure empty URL raises an exception
 SELECT pgb_session.open('');


### PR DESCRIPTION
## Summary
- enforce `pgb_session.open` to only accept URLs with `pgb://`, `http://`, or `https://` schemes
- add regression tests covering valid schemes and rejecting invalid ones

## Testing
- `sudo -u postgres bash -c 'cd tests/sql && psql -a -f session.sql postgres' 2>&1 | tail -n 40`

------
https://chatgpt.com/codex/tasks/task_e_689117cd76dc83289df5a6dbced5a0f3