### PR TITLE
Handle missing session ID with distinct error code

### DIFF
--- a/sql/60_pgb_session.sql
+++ b/sql/60_pgb_session.sql
@@ -54,7 +54,8 @@ BEGIN
     WHERE id = p_session_id;
 
     IF v_url IS NULL THEN
-        RAISE EXCEPTION 'session % not found', p_session_id;
+        RAISE EXCEPTION 'session % not found', p_session_id
+            USING ERRCODE = 'PGBSN';
     END IF;
 
     SELECT COALESCE(max(n), 0) + 1

--- a/tests/expected/reload_invalid.out
+++ b/tests/expected/reload_invalid.out
@@ -4,8 +4,11 @@ BEGIN
     BEGIN
         PERFORM pgb_session.reload(gen_random_uuid());
         RAISE EXCEPTION 'reload did not fail';
-    EXCEPTION WHEN others THEN
-        RAISE NOTICE 'error raised as expected';
+    EXCEPTION
+        WHEN sqlstate 'PGBSN' THEN
+            RAISE NOTICE 'error raised as expected';
+        WHEN others THEN
+            RAISE EXCEPTION 'unexpected error: %', SQLERRM;
     END;
 END;
 $$;

--- a/tests/expected/session.out
+++ b/tests/expected/session.out
@@ -61,7 +61,8 @@ BEGIN
     WHERE id = p_session_id;
 
     IF v_url IS NULL THEN
-        RAISE EXCEPTION 'session % not found', p_session_id;
+        RAISE EXCEPTION 'session % not found', p_session_id
+            USING ERRCODE = 'PGBSN';
     END IF;
 
     SELECT COALESCE(max(n), 0) + 1

--- a/tests/sql/reload_invalid.sql
+++ b/tests/sql/reload_invalid.sql
@@ -4,8 +4,11 @@ BEGIN
     BEGIN
         PERFORM pgb_session.reload(gen_random_uuid());
         RAISE EXCEPTION 'reload did not fail';
-    EXCEPTION WHEN others THEN
-        RAISE NOTICE 'error raised as expected';
+    EXCEPTION
+        WHEN sqlstate 'PGBSN' THEN
+            RAISE NOTICE 'error raised as expected';
+        WHEN others THEN
+            RAISE EXCEPTION 'unexpected error: %', SQLERRM;
     END;
 END;
 $$;


### PR DESCRIPTION
## Summary
- Raise explicit SQLSTATE `PGBSN` when `pgb_session.reload` is called with an unknown session ID
- Update `reload_invalid` regression test to expect this code and fail on any other result

## Testing
- `pg_regress --inputdir=/workspace/pg_browser/tests --outputdir=/workspace/pg_browser/tests/results --expecteddir=/workspace/pg_browser/tests/expected session reload_invalid` *(fails: 2 tests failed)*
- `psql -v ON_ERROR_STOP=1 -f /workspace/pg_browser/sql/00_install.sql -f /workspace/pg_browser/sql/60_pgb_session.sql -f /workspace/pg_browser/tests/sql/reload_invalid.sql`


------
https://chatgpt.com/codex/tasks/task_e_689117cba0e4832898973ad3fb0afa99