### PR TITLE
Refactor test runner to use PG env vars

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
+# Usage: PGUSER=<user> PGHOST=<host> PGDATABASE=<database> tests/run.sh
+# Runs pg_browser tests using the provided connection parameters.
 set -euo pipefail
-sudo -u postgres psql -v ON_ERROR_STOP=1 -f "$(dirname "$0")/test_pgb_session.sql" -d postgres
+psql -v ON_ERROR_STOP=1 -h "${PGHOST}" -U "${PGUSER}" -d "${PGDATABASE}" -f "$(dirname "$0")/test_pgb_session.sql"


### PR DESCRIPTION
## Summary
- run tests via environment variables instead of `sudo -u postgres`
- document environment variable usage for test runner

## Testing
- `PGUSER=root PGHOST=/var/run/postgresql PGDATABASE=postgres tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_6891506e9fbc8328a3b496f2ade1a27b