### PR TITLE
Use bigint for session history

### DIFF
--- a/sql/60_pgb_session.sql
+++ b/sql/60_pgb_session.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS pgb_session.session (
 
 CREATE TABLE IF NOT EXISTS pgb_session.history (
     session_id UUID NOT NULL REFERENCES pgb_session.session(id) ON DELETE CASCADE,
-    n INT NOT NULL,
+    n BIGINT NOT NULL,
     url TEXT NOT NULL,
     ts TIMESTAMPTZ NOT NULL DEFAULT now(),
     PRIMARY KEY(session_id, n)
@@ -51,7 +51,7 @@ LANGUAGE plpgsql
 AS $$
 DECLARE
     v_url TEXT;
-    next_n INT;
+    next_n BIGINT;
 BEGIN
     SELECT current_url INTO v_url
     FROM pgb_session.session

--- a/sql/61_pgb_session_history_bigint.sql
+++ b/sql/61_pgb_session_history_bigint.sql
@@ -1,0 +1,33 @@
+ALTER TABLE pgb_session.history
+    ALTER COLUMN n TYPE BIGINT;
+
+CREATE OR REPLACE FUNCTION pgb_session.reload(p_session_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_url TEXT;
+    next_n BIGINT;
+BEGIN
+    SELECT current_url INTO v_url
+    FROM pgb_session.session
+    WHERE id = p_session_id
+    FOR UPDATE;
+
+    IF v_url IS NULL THEN
+        RAISE EXCEPTION 'session % not found', p_session_id
+            USING ERRCODE = 'PGBSN';
+    END IF;
+
+    SELECT COALESCE(max(n), 0) + 1
+    INTO next_n
+    FROM pgb_session.history
+    WHERE session_id = p_session_id;
+
+    INSERT INTO pgb_session.history(session_id, n, url)
+    VALUES (p_session_id, next_n, v_url);
+END;
+$$;
+
+COMMENT ON FUNCTION pgb_session.reload(p_session_id UUID) IS
+    'Record a reload event. Parameters: p_session_id - session ID. Returns: void.';

--- a/tests/expected/session.out
+++ b/tests/expected/session.out
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS pgb_session.session (
 );
 CREATE TABLE IF NOT EXISTS pgb_session.history (
     session_id UUID NOT NULL REFERENCES pgb_session.session(id) ON DELETE CASCADE,
-    n INT NOT NULL,
+    n BIGINT NOT NULL,
     url TEXT NOT NULL,
     ts TIMESTAMPTZ NOT NULL DEFAULT now(),
     PRIMARY KEY(session_id, n)
@@ -52,7 +52,7 @@ LANGUAGE plpgsql
 AS $$
 DECLARE
     v_url TEXT;
-    next_n INT;
+    next_n BIGINT;
 BEGIN
     SELECT current_url INTO v_url
     FROM pgb_session.session


### PR DESCRIPTION
## Summary
- switch session history index to BIGINT and update reload routine
- add migration script to convert existing installations
- adjust regression output for new data type

## Testing
- `./tests/run.sh` *(fails: sudo: unknown user postgres)*
- `bash tests/run_regress.sh` *(fails: chown: invalid user: ‘postgres:postgres’)*

------
https://chatgpt.com/codex/tasks/task_e_6891506cefac83288df33e2d0d01494d