### PR TITLE
refactor: make regression script use env vars

### DIFF
--- a/tests/run_regress.sh
+++ b/tests/run_regress.sh
@@ -2,18 +2,22 @@
 set -euo pipefail
 
 # Run regression tests using pg_regress. Requires a running PostgreSQL server
-# accessible via local Unix socket and the `postgres` superuser.
+# accessible via settings provided via PGHOST/PGUSER environment variables.
 
 if ! command -v pg_config >/dev/null; then
   echo "pg_config not found. Install PostgreSQL development packages to run tests." >&2
   exit 1
 fi
 
-PG_REGRESS="$(pg_config --bindir)/pg_regress"
+PG_REGRESS="${PG_REGRESS:-$(pg_config --bindir)/pg_regress}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OUTPUT_DIR="$SCRIPT_DIR/results"
 mkdir -p "$OUTPUT_DIR"
-chown postgres:postgres "$OUTPUT_DIR"
 
-su postgres -c "cd $SCRIPT_DIR/sql && /usr/lib/postgresql/16/lib/pgxs/src/test/regress/pg_regress --inputdir=$SCRIPT_DIR --outputdir=$OUTPUT_DIR --expecteddir=$SCRIPT_DIR/expected session reload_invalid reload_concurrent"
+export PGUSER="${PGUSER:-postgres}"
+export PGHOST="${PGHOST:-localhost}"
+
+cd "$SCRIPT_DIR/sql"
+"$PG_REGRESS" --inputdir="$SCRIPT_DIR" --outputdir="$OUTPUT_DIR" --expecteddir="$SCRIPT_DIR/expected" \
+  session reload_invalid reload_concurrent


### PR DESCRIPTION
## Summary
- use `$PG_REGRESS` instead of a hard-coded path when running regression tests
- drop root-only `chown` and rely on `PGUSER`/`PGHOST` for connections

## Testing
- `tests/run_regress.sh` *(fails: /usr/lib/postgresql/16/bin/pg_regress: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6891506e3e4c83289373df8b0b091264