### PR TITLE
Enforce session URL scheme constraint

### DIFF
--- a/sql/60_pgb_session.sql
+++ b/sql/60_pgb_session.sql
@@ -3,7 +3,7 @@ CREATE SCHEMA IF NOT EXISTS pgb_session;
 CREATE TABLE IF NOT EXISTS pgb_session.session (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-    current_url TEXT NOT NULL,
+    current_url TEXT NOT NULL CONSTRAINT session_current_url_check CHECK (current_url ~* '^(pgb|https?)://'),
     state JSONB NOT NULL DEFAULT '{}'::jsonb,
     focus UUID
 );

--- a/sql/61_add_session_current_url_check.sql
+++ b/sql/61_add_session_current_url_check.sql
@@ -1,0 +1,9 @@
+DO $$
+BEGIN
+    ALTER TABLE pgb_session.session
+        ADD CONSTRAINT session_current_url_check
+        CHECK (current_url ~* '^(pgb|https?)://');
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END
+$$;

--- a/tests/expected/session.out
+++ b/tests/expected/session.out
@@ -6,7 +6,7 @@ CREATE SCHEMA IF NOT EXISTS pgb_session;
 CREATE TABLE IF NOT EXISTS pgb_session.session (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-    current_url TEXT NOT NULL,
+    current_url TEXT NOT NULL CONSTRAINT session_current_url_check CHECK (current_url ~* '^(pgb|https?)://'),
     state JSONB NOT NULL DEFAULT '{}'::jsonb,
     focus UUID
 );
@@ -42,10 +42,8 @@ BEGIN
     RETURN sid;
 END;
 $$;
-
 COMMENT ON FUNCTION pgb_session.open(p_url TEXT) IS
     'Open a new session. Parameters: p_url - initial URL. Returns: session UUID.';
-
 CREATE OR REPLACE FUNCTION pgb_session.reload(p_session_id UUID)
 RETURNS VOID
 LANGUAGE plpgsql
@@ -73,9 +71,10 @@ BEGIN
     VALUES (p_session_id, next_n, v_url);
 END;
 $$;
-
 COMMENT ON FUNCTION pgb_session.reload(p_session_id UUID) IS
     'Record a reload event. Parameters: p_session_id - session ID. Returns: void.';
+SET TIME ZONE 'UTC';
+SET datestyle TO ISO, YMD;
 -- Open a new session and capture the ID
 SELECT pgb_session.open('pgb://local/demo') AS sid \gset
 -- Ensure an ID is returned
@@ -121,9 +120,14 @@ SELECT pgb_session.open('https://example.com') IS NOT NULL AS https_opened;
 
 -- Reject invalid URL scheme
 SELECT pgb_session.open('ftp://example.com');
-psql:session.sql:25: ERROR:  unsupported URL scheme: ftp://example.com
+ERROR:  unsupported URL scheme: ftp://example.com
 CONTEXT:  PL/pgSQL function pgb_session.open(text) line 10 at RAISE
+-- Reject invalid URL scheme on direct insert
+INSERT INTO pgb_session.session(id, created_at, current_url)
+VALUES ('00000000-0000-0000-0000-000000000000', '2000-01-01 00:00:00+00', 'ftp://example.com');
+ERROR:  new row for relation "session" violates check constraint "session_current_url_check"
+DETAIL:  Failing row contains (00000000-0000-0000-0000-000000000000, 2000-01-01 00:00:00+00, ftp://example.com, {}, null).
 -- Ensure empty URL raises an exception
 SELECT pgb_session.open('');
-psql:session.sql:28: ERROR:  url must not be empty
+ERROR:  url must not be empty
 CONTEXT:  PL/pgSQL function pgb_session.open(text) line 6 at RAISE

--- a/tests/sql/session.sql
+++ b/tests/sql/session.sql
@@ -2,6 +2,9 @@
 \ir ../../sql/00_install.sql
 \ir ../../sql/60_pgb_session.sql
 
+SET TIME ZONE 'UTC';
+SET datestyle TO ISO, YMD;
+
 -- Open a new session and capture the ID
 SELECT pgb_session.open('pgb://local/demo') AS sid \gset
 
@@ -23,6 +26,10 @@ SELECT pgb_session.open('https://example.com') IS NOT NULL AS https_opened;
 
 -- Reject invalid URL scheme
 SELECT pgb_session.open('ftp://example.com');
+
+-- Reject invalid URL scheme on direct insert
+INSERT INTO pgb_session.session(id, created_at, current_url)
+VALUES ('00000000-0000-0000-0000-000000000000', '2000-01-01 00:00:00+00', 'ftp://example.com');
 
 -- Ensure empty URL raises an exception
 SELECT pgb_session.open('');


### PR DESCRIPTION
## Summary
- Require `pgb_session.session.current_url` to use pgb/http/https schemes via a check constraint
- Add migration to apply the new constraint to existing databases
- Extend regression tests to verify invalid URL schemes are rejected even on direct insert

## Testing
- `bash tests/run.sh`
- `bash tests/run_regress.sh`


------
https://chatgpt.com/codex/tasks/task_e_6891506bf9e08328bb8bc7fc200a284e