### PR TITLE
Allow case-insensitive URL schemes

### DIFF
--- a/sql/60_pgb_session.sql
+++ b/sql/60_pgb_session.sql
@@ -27,7 +27,7 @@ BEGIN
         RAISE EXCEPTION 'url must not be empty';
     END IF;
 
-    IF p_url !~ '^(pgb|https?)://' THEN
+    IF p_url !~* '^(pgb|https?)://' THEN
         RAISE EXCEPTION 'unsupported URL scheme: %', p_url;
     END IF;
 

--- a/tests/expected/session.out
+++ b/tests/expected/session.out
@@ -28,7 +28,7 @@ BEGIN
         RAISE EXCEPTION 'url must not be empty';
     END IF;
 
-    IF p_url !~ '^(pgb|https?)://' THEN
+    IF p_url !~* '^(pgb|https?)://' THEN
         RAISE EXCEPTION 'unsupported URL scheme: %', p_url;
     END IF;
 
@@ -42,10 +42,8 @@ BEGIN
     RETURN sid;
 END;
 $$;
-
 COMMENT ON FUNCTION pgb_session.open(p_url TEXT) IS
     'Open a new session. Parameters: p_url - initial URL. Returns: session UUID.';
-
 CREATE OR REPLACE FUNCTION pgb_session.reload(p_session_id UUID)
 RETURNS VOID
 LANGUAGE plpgsql
@@ -73,7 +71,6 @@ BEGIN
     VALUES (p_session_id, next_n, v_url);
 END;
 $$;
-
 COMMENT ON FUNCTION pgb_session.reload(p_session_id UUID) IS
     'Record a reload event. Parameters: p_session_id - session ID. Returns: void.';
 -- Open a new session and capture the ID
@@ -119,11 +116,24 @@ SELECT pgb_session.open('https://example.com') IS NOT NULL AS https_opened;
  t
 (1 row)
 
+-- Accept uppercase URL schemes
+SELECT pgb_session.open('HTTP://example.com') IS NOT NULL AS http_upper_opened;
+ http_upper_opened 
+-------------------
+ t
+(1 row)
+
+SELECT pgb_session.open('HTTPS://example.com') IS NOT NULL AS https_upper_opened;
+ https_upper_opened 
+--------------------
+ t
+(1 row)
+
 -- Reject invalid URL scheme
 SELECT pgb_session.open('ftp://example.com');
-psql:session.sql:25: ERROR:  unsupported URL scheme: ftp://example.com
+ERROR:  unsupported URL scheme: ftp://example.com
 CONTEXT:  PL/pgSQL function pgb_session.open(text) line 10 at RAISE
 -- Ensure empty URL raises an exception
 SELECT pgb_session.open('');
-psql:session.sql:28: ERROR:  url must not be empty
+ERROR:  url must not be empty
 CONTEXT:  PL/pgSQL function pgb_session.open(text) line 6 at RAISE

--- a/tests/sql/session.sql
+++ b/tests/sql/session.sql
@@ -21,6 +21,10 @@ SELECT count(*) AS history_count FROM pgb_session.history;
 SELECT pgb_session.open('http://example.com') IS NOT NULL AS http_opened;
 SELECT pgb_session.open('https://example.com') IS NOT NULL AS https_opened;
 
+-- Accept uppercase URL schemes
+SELECT pgb_session.open('HTTP://example.com') IS NOT NULL AS http_upper_opened;
+SELECT pgb_session.open('HTTPS://example.com') IS NOT NULL AS https_upper_opened;
+
 -- Reject invalid URL scheme
 SELECT pgb_session.open('ftp://example.com');
 


### PR DESCRIPTION
## Summary
- use case-insensitive regex for URL scheme validation
- add regression coverage for uppercase HTTP and HTTPS schemes

## Testing
- `tests/run.sh`
- `bash tests/run_regress.sh`


------
https://chatgpt.com/codex/tasks/task_e_6891506baf688328aca371304cd6e3a2