### PR TITLE
refactor reload function upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,20 @@ Optional:
 CREATE EXTENSION IF NOT EXISTS http;
 ```
 
+### Upgrade
+
+For installations created before the `pgb_session.history.n` column used
+`BIGINT`, run the upgrade script:
+
+```bash
+psql -d yourdb -f sql/61_pgb_session_history_bigint.sql
+```
+
+This script redefines `pgb_session.reload` by including
+`sql/60_pgb_session_reload.sql`, keeping the function's definition in one
+place. Modify `sql/60_pgb_session_reload.sql` if the function body needs to
+change.
+
 ---
 
 ## Quickstart (design preview)

--- a/sql/60_pgb_session.sql
+++ b/sql/60_pgb_session.sql
@@ -45,33 +45,4 @@ $$;
 COMMENT ON FUNCTION pgb_session.open(p_url TEXT) IS
     'Open a new session. Parameters: p_url - initial URL. Returns: session UUID.';
 
-CREATE OR REPLACE FUNCTION pgb_session.reload(p_session_id UUID)
-RETURNS VOID
-LANGUAGE plpgsql
-AS $$
-DECLARE
-    v_url TEXT;
-    next_n BIGINT;
-BEGIN
-    SELECT current_url INTO v_url
-    FROM pgb_session.session
-    WHERE id = p_session_id
-    FOR UPDATE;
-
-    IF v_url IS NULL THEN
-        RAISE EXCEPTION 'session % not found', p_session_id
-            USING ERRCODE = 'PGBSN';
-    END IF;
-
-    SELECT COALESCE(max(n), 0) + 1
-    INTO next_n
-    FROM pgb_session.history
-    WHERE session_id = p_session_id;
-
-    INSERT INTO pgb_session.history(session_id, n, url)
-    VALUES (p_session_id, next_n, v_url);
-END;
-$$;
-
-COMMENT ON FUNCTION pgb_session.reload(p_session_id UUID) IS
-    'Record a reload event. Parameters: p_session_id - session ID. Returns: void.';
+\ir 60_pgb_session_reload.sql

--- a/sql/60_pgb_session_reload.sql
+++ b/sql/60_pgb_session_reload.sql
@@ -1,0 +1,30 @@
+CREATE OR REPLACE FUNCTION pgb_session.reload(p_session_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_url TEXT;
+    next_n BIGINT;
+BEGIN
+    SELECT current_url INTO v_url
+    FROM pgb_session.session
+    WHERE id = p_session_id
+    FOR UPDATE;
+
+    IF v_url IS NULL THEN
+        RAISE EXCEPTION 'session % not found', p_session_id
+            USING ERRCODE = 'PGBSN';
+    END IF;
+
+    SELECT COALESCE(max(n), 0) + 1
+    INTO next_n
+    FROM pgb_session.history
+    WHERE session_id = p_session_id;
+
+    INSERT INTO pgb_session.history(session_id, n, url)
+    VALUES (p_session_id, next_n, v_url);
+END;
+$$;
+
+COMMENT ON FUNCTION pgb_session.reload(p_session_id UUID) IS
+    'Record a reload event. Parameters: p_session_id - session ID. Returns: void.';

--- a/sql/61_pgb_session_history_bigint.sql
+++ b/sql/61_pgb_session_history_bigint.sql
@@ -1,33 +1,4 @@
 ALTER TABLE pgb_session.history
     ALTER COLUMN n TYPE BIGINT;
 
-CREATE OR REPLACE FUNCTION pgb_session.reload(p_session_id UUID)
-RETURNS VOID
-LANGUAGE plpgsql
-AS $$
-DECLARE
-    v_url TEXT;
-    next_n BIGINT;
-BEGIN
-    SELECT current_url INTO v_url
-    FROM pgb_session.session
-    WHERE id = p_session_id
-    FOR UPDATE;
-
-    IF v_url IS NULL THEN
-        RAISE EXCEPTION 'session % not found', p_session_id
-            USING ERRCODE = 'PGBSN';
-    END IF;
-
-    SELECT COALESCE(max(n), 0) + 1
-    INTO next_n
-    FROM pgb_session.history
-    WHERE session_id = p_session_id;
-
-    INSERT INTO pgb_session.history(session_id, n, url)
-    VALUES (p_session_id, next_n, v_url);
-END;
-$$;
-
-COMMENT ON FUNCTION pgb_session.reload(p_session_id UUID) IS
-    'Record a reload event. Parameters: p_session_id - session ID. Returns: void.';
+\ir 60_pgb_session_reload.sql


### PR DESCRIPTION
## Summary
- Extract `pgb_session.reload` definition into `sql/60_pgb_session_reload.sql` to avoid duplication
- Use `\ir` to include reload function in install and upgrade scripts, keeping single source of truth
- Document upgrade path for big integer history column

## Testing
- `./tests/run_regress.sh` *(fails: /usr/lib/postgresql/16/bin/pg_regress: No such file or directory)*
- `PGHOST=localhost PGUSER=postgres PGDATABASE=postgres tests/run.sh` *(fails: psql: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6891552da8d88328bfcbafa04f254d72