### PR TITLE
Add session close function with cascading deletion

### DIFF
--- a/sql/60_pgb_session.sql
+++ b/sql/60_pgb_session.sql
@@ -75,3 +75,21 @@ $$;
 
 COMMENT ON FUNCTION pgb_session.reload(p_session_id UUID) IS
     'Record a reload event. Parameters: p_session_id - session ID. Returns: void.';
+
+CREATE OR REPLACE FUNCTION pgb_session.close(p_session_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    DELETE FROM pgb_session.session
+    WHERE id = p_session_id;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'session % not found', p_session_id
+            USING ERRCODE = 'PGBSN';
+    END IF;
+END;
+$$;
+
+COMMENT ON FUNCTION pgb_session.close(p_session_id UUID) IS
+    'Close and delete a session. Parameters: p_session_id - session ID. Deletes session and history via cascade. Returns: void.';

--- a/tests/expected/session.out
+++ b/tests/expected/session.out
@@ -73,6 +73,22 @@ END;
 $$;
 COMMENT ON FUNCTION pgb_session.reload(p_session_id UUID) IS
     'Record a reload event. Parameters: p_session_id - session ID. Returns: void.';
+CREATE OR REPLACE FUNCTION pgb_session.close(p_session_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    DELETE FROM pgb_session.session
+    WHERE id = p_session_id;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'session % not found', p_session_id
+            USING ERRCODE = 'PGBSN';
+    END IF;
+END;
+$$;
+COMMENT ON FUNCTION pgb_session.close(p_session_id UUID) IS
+    'Close and delete a session. Parameters: p_session_id - session ID. Deletes session and history via cascade. Returns: void.';
 SET TIME ZONE 'UTC';
 SET datestyle TO ISO, YMD;
 -- Open a new session and capture the ID
@@ -103,6 +119,26 @@ SELECT count(*) AS history_count FROM pgb_session.history;
  history_count 
 ---------------
              2
+(1 row)
+
+-- Close the session
+SELECT pgb_session.close(:'sid');
+ close 
+-------
+ 
+(1 row)
+
+-- Verify session and history cleared
+SELECT count(*) AS session_count_after_close FROM pgb_session.session;
+ session_count_after_close 
+---------------------------
+                         0
+(1 row)
+
+SELECT count(*) AS history_count_after_close FROM pgb_session.history;
+ history_count_after_close 
+---------------------------
+                         0
 (1 row)
 
 -- Accept valid URL schemes

--- a/tests/sql/session.sql
+++ b/tests/sql/session.sql
@@ -20,6 +20,13 @@ SELECT count(*) AS session_count FROM pgb_session.session;
 -- Verify history table has two entries
 SELECT count(*) AS history_count FROM pgb_session.history;
 
+-- Close the session
+SELECT pgb_session.close(:'sid');
+
+-- Verify session and history cleared
+SELECT count(*) AS session_count_after_close FROM pgb_session.session;
+SELECT count(*) AS history_count_after_close FROM pgb_session.history;
+
 -- Accept valid URL schemes
 SELECT pgb_session.open('http://example.com') IS NOT NULL AS http_opened;
 SELECT pgb_session.open('https://example.com') IS NOT NULL AS https_opened;

--- a/tests/test_pgb_session.sql
+++ b/tests/test_pgb_session.sql
@@ -26,6 +26,20 @@ BEGIN
     ) THEN
         RAISE EXCEPTION 'history row missing or incorrect';
     END IF;
+
+    PERFORM pgb_session.close(sid);
+
+    IF EXISTS (
+        SELECT 1 FROM pgb_session.session WHERE id = sid
+    ) THEN
+        RAISE EXCEPTION 'session row not deleted';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM pgb_session.history WHERE session_id = sid
+    ) THEN
+        RAISE EXCEPTION 'history rows not deleted';
+    END IF;
 END;
 $$;
 

--- a/tests/test_session_open.sh
+++ b/tests/test_session_open.sh
@@ -28,4 +28,19 @@ if [[ "$COUNT" -ne 1 ]]; then
   exit 1
 fi
 
+# Close the session
+sudo -u postgres psql -d "$DB" -v ON_ERROR_STOP=1 -c "SELECT pgb_session.close('$SESSION_ID');" >/dev/null
+
+COUNT=$(sudo -u postgres psql -d "$DB" -t -A -c "SELECT count(*) FROM pgb_session.session WHERE id = '$SESSION_ID';")
+if [[ "$COUNT" -ne 0 ]]; then
+  echo "session row not deleted"
+  exit 1
+fi
+
+COUNT=$(sudo -u postgres psql -d "$DB" -t -A -c "SELECT count(*) FROM pgb_session.history WHERE session_id = '$SESSION_ID';")
+if [[ "$COUNT" -ne 0 ]]; then
+  echo "history rows not deleted"
+  exit 1
+fi
+
 echo "session_open integration test passed"


### PR DESCRIPTION
## Summary
- add `pgb_session.close` for deleting sessions and cascading history
- test session removal in unit, regression, and integration scripts

## Testing
- `sudo -E -u postgres PGUSER=postgres PGHOST=/var/run/postgresql PGDATABASE=postgres tests/run.sh`
- `sudo -E -u postgres PGHOST=/var/run/postgresql PGUSER=postgres PG_REGRESS=/usr/lib/postgresql/16/lib/pgxs/src/test/regress/pg_regress tests/run_regress.sh`
- `tests/test_session_open.sh`


------
https://chatgpt.com/codex/tasks/task_e_689155306f4483288e4d7157f0f5f3f0