### PR TITLE
Handle missing PG connection variables in test runner

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -2,4 +2,11 @@
 # Usage: PGUSER=<user> PGHOST=<host> PGDATABASE=<database> tests/run.sh
 # Runs pg_browser tests using the provided connection parameters.
 set -euo pipefail
-psql -v ON_ERROR_STOP=1 -h "${PGHOST}" -U "${PGUSER}" -d "${PGDATABASE}" -f "$(dirname "$0")/test_pgb_session.sql"
+
+# Use default connection parameters when not provided to avoid unbound
+# variable errors. These mirror the defaults used by run_regress.sh.
+export PGUSER="${PGUSER:-postgres}"
+export PGHOST="${PGHOST:-localhost}"
+export PGDATABASE="${PGDATABASE:-postgres}"
+
+psql -v ON_ERROR_STOP=1 -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" -f "$(dirname "$0")/test_pgb_session.sql"


### PR DESCRIPTION
## Summary
- avoid unbound PG vars by defaulting to localhost postgres connection in `tests/run.sh`

## Testing
- `tests/run.sh` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6891fcc7d5d883289ba8f9450556083a