### PR TITLE
Expect updated history length after reload

### DIFF
--- a/tests/test_pgb_session.sql
+++ b/tests/test_pgb_session.sql
@@ -105,7 +105,7 @@ BEGIN
             ORDER BY h.n DESC
             LIMIT 1
         ) h ON true
-        WHERE s.id = sid AND h.n = 2 AND h.url = s.current_url
+        WHERE s.id = sid AND h.n = 4 AND h.url = s.current_url
     ) THEN
         RAISE EXCEPTION 'reload did not update history correctly';
     END IF;


### PR DESCRIPTION
## Summary
- update reload test to verify history index advances to 4

## Testing
- `PGHOST=/var/run/postgresql sudo -E -u postgres tests/run.sh` *(fails: column "sid" does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6892814ae0088328a8bbb4dbb9edb451