### PR TITLE
Extract pgb_session.open into reusable script

### DIFF
--- a/sql/60_pgb_session.sql
+++ b/sql/60_pgb_session.sql
@@ -24,34 +24,7 @@ CREATE TABLE IF NOT EXISTS pgb_session.snapshot (
     PRIMARY KEY(session_id, ts)
 );
 
-CREATE OR REPLACE FUNCTION pgb_session.open(p_url TEXT)
-RETURNS UUID
-LANGUAGE plpgsql
-AS $$
-DECLARE
-    sid UUID;
-BEGIN
-    IF p_url IS NULL OR p_url = '' THEN
-        RAISE EXCEPTION 'url must not be empty';
-    END IF;
-
-    IF p_url !~* '^(pgb|https?)://' THEN
-        RAISE EXCEPTION 'unsupported URL scheme: %', p_url;
-    END IF;
-
-    INSERT INTO pgb_session.session(current_url)
-    VALUES (p_url)
-    RETURNING id INTO sid;
-
-    INSERT INTO pgb_session.history(session_id, url)
-    VALUES (sid, p_url);
-
-    RETURN sid;
-END;
-$$;
-
-COMMENT ON FUNCTION pgb_session.open(p_url TEXT) IS
-    'Open a new session. Parameters: p_url - initial URL. Returns: session UUID.';
+\ir 60_pgb_session_open.sql
 
 CREATE OR REPLACE FUNCTION pgb_session.navigate(p_session_id UUID, p_url TEXT)
 RETURNS VOID

--- a/sql/60_pgb_session_open.sql
+++ b/sql/60_pgb_session_open.sql
@@ -1,0 +1,28 @@
+CREATE OR REPLACE FUNCTION pgb_session.open(p_url TEXT)
+RETURNS UUID
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    sid UUID;
+BEGIN
+    IF p_url IS NULL OR p_url = '' THEN
+        RAISE EXCEPTION 'url must not be empty';
+    END IF;
+
+    IF p_url !~* '^(pgb|https?)://' THEN
+        RAISE EXCEPTION 'unsupported URL scheme: %', p_url;
+    END IF;
+
+    INSERT INTO pgb_session.session(current_url)
+    VALUES (p_url)
+    RETURNING id INTO sid;
+
+    INSERT INTO pgb_session.history(session_id, url)
+    VALUES (sid, p_url);
+
+    RETURN sid;
+END;
+$$;
+
+COMMENT ON FUNCTION pgb_session.open(p_url TEXT) IS
+    'Open a new session. Parameters: p_url - initial URL. Returns: session UUID.';

--- a/sql/61_pgb_session_history_bigint.sql
+++ b/sql/61_pgb_session_history_bigint.sql
@@ -8,33 +8,6 @@ SELECT setval(
     true
 );
 
-CREATE OR REPLACE FUNCTION pgb_session.open(p_url TEXT)
-RETURNS UUID
-LANGUAGE plpgsql
-AS $$
-DECLARE
-    sid UUID;
-BEGIN
-    IF p_url IS NULL OR p_url = '' THEN
-        RAISE EXCEPTION 'url must not be empty';
-    END IF;
+\ir 60_pgb_session_open.sql
 
-    IF p_url !~* '^(pgb|https?)://' THEN
-        RAISE EXCEPTION 'unsupported URL scheme: %', p_url;
-    END IF;
-
-    INSERT INTO pgb_session.session(current_url)
-    VALUES (p_url)
-    RETURNING id INTO sid;
-
-    INSERT INTO pgb_session.history(session_id, url)
-    VALUES (sid, p_url);
-
-    RETURN sid;
-END;
-$$;
-
-COMMENT ON FUNCTION pgb_session.open(p_url TEXT) IS
-    'Open a new session. Parameters: p_url - initial URL. Returns: session UUID.';
-    
 \ir 60_pgb_session_reload.sql


### PR DESCRIPTION
## Summary
- move `pgb_session.open` function into its own `60_pgb_session_open.sql`
- reference the new script from session and migration SQL files to remove duplication

## Testing
- `sudo -u postgres PGHOST=/var/run/postgresql tests/run.sh` *(fails: reload did not update history correctly)*
- `sudo -u postgres PGHOST=/var/run/postgresql PG_REGRESS=/usr/lib/postgresql/16/lib/pgxs/src/test/regress/pg_regress tests/run_regress.sh` *(fails: 1 of 3 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68928147faf48328bab464a265d645ce