### PR TITLE
Lock session row during replay

### DIFF
--- a/sql/60_pgb_session.sql
+++ b/sql/60_pgb_session.sql
@@ -101,6 +101,18 @@ DECLARE
     v_url TEXT;
     v_snap_ts TIMESTAMPTZ;
 BEGIN
+    -- Acquire a lock on the session row to ensure consistency for
+    -- subsequent updates and deletes.
+    PERFORM 1
+    FROM pgb_session.session
+    WHERE id = p_session_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'session % not found', p_session_id
+            USING ERRCODE = 'PGBSN';
+    END IF;
+
     SELECT state, current_url, ts
     INTO v_state, v_url, v_snap_ts
     FROM pgb_session.snapshot


### PR DESCRIPTION
## Summary
- Acquire FOR UPDATE lock on session row in `pgb_session.replay` before applying snapshot
- Raise `session not found` error when locking fails

## Testing
- `tests/run.sh` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6892814793d08328a8cbe86e21687f93