### PR TITLE
Add SQLSTATE for missing snapshots and tests

### DIFF
--- a/sql/60_pgb_session.sql
+++ b/sql/60_pgb_session.sql
@@ -96,7 +96,7 @@ BEGIN
 
     IF NOT FOUND THEN
         RAISE EXCEPTION 'snapshot not found for session % at %', p_session_id, p_ts
-            USING ERRCODE = 'PGBSN';
+            USING ERRCODE = 'PGBNS';
     END IF;
 
     UPDATE pgb_session.session

--- a/tests/expected/replay.out
+++ b/tests/expected/replay.out
@@ -108,7 +108,7 @@ BEGIN
 
     IF NOT FOUND THEN
         RAISE EXCEPTION 'snapshot not found for session % at %', p_session_id, p_ts
-            USING ERRCODE = 'PGBSN';
+            USING ERRCODE = 'PGBNS';
     END IF;
 
     UPDATE pgb_session.session

--- a/tests/expected/replay_invalid.out
+++ b/tests/expected/replay_invalid.out
@@ -1,0 +1,30 @@
+-- Attempt to replay non-existent session and missing snapshot; should raise distinct errors
+DO $$
+DECLARE
+    sid UUID;
+BEGIN
+    BEGIN
+        PERFORM pgb_session.replay(gen_random_uuid(), clock_timestamp());
+        RAISE EXCEPTION 'replay did not fail for missing session';
+    EXCEPTION
+        WHEN sqlstate 'PGBSN' THEN
+            RAISE NOTICE 'session error raised as expected';
+        WHEN others THEN
+            RAISE EXCEPTION 'unexpected error: %', SQLERRM;
+    END;
+
+    sid := pgb_session.open('pgb://local/demo');
+    BEGIN
+        PERFORM pgb_session.replay(sid, clock_timestamp());
+        RAISE EXCEPTION 'replay did not fail for missing snapshot';
+    EXCEPTION
+        WHEN sqlstate 'PGBNS' THEN
+            RAISE NOTICE 'snapshot error raised as expected';
+        WHEN others THEN
+            RAISE EXCEPTION 'unexpected error: %', SQLERRM;
+    END;
+    PERFORM pgb_session.close(sid);
+END;
+$$;
+NOTICE:  session error raised as expected
+NOTICE:  snapshot error raised as expected

--- a/tests/expected/session.out
+++ b/tests/expected/session.out
@@ -135,7 +135,7 @@ BEGIN
 
     IF NOT FOUND THEN
         RAISE EXCEPTION 'snapshot not found for session % at %', p_session_id, p_ts
-            USING ERRCODE = 'PGBSN';
+            USING ERRCODE = 'PGBNS';
     END IF;
 
     UPDATE pgb_session.session

--- a/tests/run_regress.sh
+++ b/tests/run_regress.sh
@@ -20,4 +20,4 @@ export PGHOST="${PGHOST:-localhost}"
 
 cd "$SCRIPT_DIR/sql"
 "$PG_REGRESS" --inputdir="$SCRIPT_DIR" --outputdir="$OUTPUT_DIR" --expecteddir="$SCRIPT_DIR/expected" \
-  session reload_invalid reload_concurrent replay
+  session reload_invalid reload_concurrent replay replay_invalid


### PR DESCRIPTION
## Summary
- introduce SQLSTATE `PGBNS` for missing session snapshots
- test replay for missing session and missing snapshot
- check replay error codes in test script

## Testing
- `su postgres -c "cd /workspace/pg_browser && PSQL_ECHO=none PGHOST=/var/run/postgresql PG_REGRESS=/usr/lib/postgresql/16/lib/pgxs/src/test/regress/pg_regress tests/run_regress.sh"` (fails: 2 of 5 tests failed)
- `su postgres -c "psql -v ON_ERROR_STOP=1 -f sql/00_install.sql -f sql/60_pgb_session.sql -f tests/sql/replay_invalid.sql" | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_689386505f208328af68ebeed9879a77