### PR TITLE
fix regress test list

### DIFF
--- a/tests/run_regress.sh
+++ b/tests/run_regress.sh
@@ -20,8 +20,5 @@ export PGHOST="${PGHOST:-localhost}"
 
 cd "$SCRIPT_DIR/sql"
 "$PG_REGRESS" --inputdir="$SCRIPT_DIR" --outputdir="$OUTPUT_DIR" --expecteddir="$SCRIPT_DIR/expected" \
-
-  session reload_invalid reload_concurrent replay replay_missing_snapshot
-
-  session reload_invalid reload_concurrent replay replay_invalid
+  session reload_invalid reload_concurrent replay replay_missing_snapshot replay_invalid
 


### PR DESCRIPTION
## Summary
- fix test command in run_regress script

## Testing
- `bash tests/run_regress.sh >/tmp/test.log && tail -n 20 /tmp/test.log` *(fails: /usr/lib/postgresql/16/bin/pg_regress: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68939257298883288fbb15ca2422aa9e