### PR TITLE
Close outer DO block in session test script

### DIFF
--- a/tests/test_pgb_session.sql
+++ b/tests/test_pgb_session.sql
@@ -130,6 +130,9 @@ BEGIN
     END IF;
 
 
+END;
+$$;
+
 DO $$
 DECLARE
     sid2 UUID;


### PR DESCRIPTION
## Summary
- terminate the first `DO` block before starting a second in `test_pgb_session.sql`

## Testing
- `tests/run.sh` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689392560a2c8328a7701ed331d9a811