### PR TITLE
Use NOT FOUND to detect missing session row in reload

### DIFF
--- a/sql/60_pgb_session_reload.sql
+++ b/sql/60_pgb_session_reload.sql
@@ -11,7 +11,7 @@ BEGIN
     WHERE id = p_session_id
     FOR UPDATE;
 
-    IF v_url IS NULL THEN
+    IF NOT FOUND THEN
         RAISE EXCEPTION 'session % not found', p_session_id
             USING ERRCODE = 'PGBSN';
     END IF;


### PR DESCRIPTION
## Summary
- ensure `pgb_session.reload` checks query result via `NOT FOUND` instead of null assignment
- keep existing exception when session row does not exist

## Testing
- `tests/run.sh` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6893961cdcd083288ec01d7888195ab4