### PR TITLE
Set PGPASSWORD for tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
             psql -h localhost -U postgres -d pg_browser_test -f "$file"
           done
       - name: Run tests
+        env:
+          PGPASSWORD: postgres
         run: |
           set +e
           tests/run.sh


### PR DESCRIPTION
## Summary
- Ensure tests step uses preset password to access Postgres service

## Testing
- `PGPASSWORD=postgres PGUSER=postgres PGHOST=localhost PGDATABASE=pg_browser_test tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_6893961bfe6c8328be208ad6b43e469e