### PR TITLE
Add concurrent navigate regression test

### DIFF
--- a/tests/expected/navigate_concurrent.out
+++ b/tests/expected/navigate_concurrent.out
@@ -1,0 +1,66 @@
+-- Test concurrent navigations to ensure unique history entries
+CREATE EXTENSION IF NOT EXISTS dblink;
+-- Open a new session and capture the ID
+SELECT pgb_session.open('pgb://local/demo') AS sid \gset
+-- Establish two connections for concurrent navigations
+SELECT dblink_connect('c1', 'dbname=' || current_database());
+ dblink_connect
+----------------
+ OK
+(1 row)
+
+SELECT dblink_connect('c2', 'dbname=' || current_database());
+ dblink_connect
+----------------
+ OK
+(1 row)
+
+-- Launch navigations concurrently
+SELECT dblink_send_query('c1', format('SELECT pgb_session.navigate(''%s'', ''http://example.com/a'')', :'sid'));
+ dblink_send_query
+-------------------
+                 1
+(1 row)
+
+SELECT dblink_send_query('c2', format('SELECT pgb_session.navigate(''%s'', ''http://example.com/b'')', :'sid'));
+ dblink_send_query
+-------------------
+                 1
+(1 row)
+
+-- Wait for both navigations to complete
+SELECT * FROM dblink_get_result('c1') AS t(result text);
+ result
+--------
+
+(1 row)
+
+SELECT * FROM dblink_get_result('c2') AS t(result text);
+ result
+--------
+
+(1 row)
+
+-- Verify history sequence numbers are unique and sequential
+SELECT array_agg(n - min_n ORDER BY n) AS ns
+FROM (
+    SELECT n, min(n) OVER () AS min_n
+    FROM pgb_session.history
+    WHERE session_id = :'sid'
+) s;
+   ns
+---------
+ {0,1,2}
+(1 row)
+
+SELECT dblink_disconnect('c1');
+ dblink_disconnect
+-------------------
+ OK
+(1 row)
+
+SELECT dblink_disconnect('c2');
+ dblink_disconnect
+-------------------
+ OK
+(1 row)

--- a/tests/run_regress.sh
+++ b/tests/run_regress.sh
@@ -20,5 +20,5 @@ export PGHOST="${PGHOST:-localhost}"
 
 cd "$SCRIPT_DIR/sql"
 "$PG_REGRESS" --inputdir="$SCRIPT_DIR" --outputdir="$OUTPUT_DIR" --expecteddir="$SCRIPT_DIR/expected" \
-  session reload_invalid reload_concurrent replay replay_missing_snapshot replay_invalid
+  session reload_invalid reload_concurrent navigate_concurrent replay replay_missing_snapshot replay_invalid
 

--- a/tests/sql/navigate_concurrent.sql
+++ b/tests/sql/navigate_concurrent.sql
@@ -1,0 +1,28 @@
+-- Test concurrent navigations to ensure unique history entries
+CREATE EXTENSION IF NOT EXISTS dblink;
+
+-- Open a new session and capture the ID
+SELECT pgb_session.open('pgb://local/demo') AS sid \gset
+
+-- Establish two connections for concurrent navigations
+SELECT dblink_connect('c1', 'dbname=' || current_database());
+SELECT dblink_connect('c2', 'dbname=' || current_database());
+
+-- Launch navigations concurrently
+SELECT dblink_send_query('c1', format('SELECT pgb_session.navigate(''%s'', ''http://example.com/a'')', :'sid'));
+SELECT dblink_send_query('c2', format('SELECT pgb_session.navigate(''%s'', ''http://example.com/b'')', :'sid'));
+
+-- Wait for both navigations to complete
+SELECT * FROM dblink_get_result('c1') AS t(result text);
+SELECT * FROM dblink_get_result('c2') AS t(result text);
+
+-- Verify history sequence numbers are unique and sequential
+SELECT array_agg(n - min_n ORDER BY n) AS ns
+FROM (
+    SELECT n, min(n) OVER () AS min_n
+    FROM pgb_session.history
+    WHERE session_id = :'sid'
+) s;
+
+SELECT dblink_disconnect('c1');
+SELECT dblink_disconnect('c2');


### PR DESCRIPTION
## Summary
- Add navigate_concurrent regression test exercising concurrent navigation requests
- Provide expected output for new test
- Run new test as part of run_regress.sh

## Testing
- `PG_REGRESS=/usr/lib/postgresql/16/lib/pgxs/src/test/regress/pg_regress tests/run_regress.sh` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689d275d4c1883288287764f55372d7b