### PR TITLE
Document SQLSTATE error codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,17 @@ accessible as the `postgres` superuser). The script uses `pg_config` to locate
 `postgresql-server-dev-16` on Debian/Ubuntu) if `pg_config` is not available.
 Additional integration tests live in the same directory.
 
+## Error Codes
+
+The project defines custom `SQLSTATE` values. Keep this list up to date when
+introducing new codes.
+
+| Code   | Raised when |
+|--------|-------------|
+| `PGBUV` | A URL is empty or fails validation in `pgb_session.validate_url` and functions that call it. |
+| `PGBSN` | A session ID does not match an existing session (`pgb_session.navigate`, `pgb_session.reload`, `pgb_session.replay`, `pgb_session.close`). |
+| `PGBNS` | A snapshot for the requested session and timestamp cannot be found (`pgb_session.replay`). |
+
 ---
 
 ## Contributing
@@ -227,6 +238,7 @@ Additional integration tests live in the same directory.
   - example usage,
   - unit test (where applicable),
   - migration script.
+- Document new `SQLSTATE` codes in the **Error Codes** section of this README.
 
 ---
 

--- a/sql/60_pgb_session.sql
+++ b/sql/60_pgb_session.sql
@@ -84,7 +84,7 @@ END;
 $$;
 
 COMMENT ON FUNCTION pgb_session.navigate(p_session_id UUID, p_url TEXT) IS
-    'Navigate to a new URL. Parameters: p_session_id - session ID; p_url - destination URL. Returns: void.';
+    'Navigate to a new URL. Raises SQLSTATE PGBSN if the session does not exist and PGBUV if the URL is invalid. Parameters: p_session_id - session ID; p_url - destination URL. Returns: void.';
 
 \ir 60_pgb_session_reload.sql
 
@@ -143,7 +143,7 @@ END;
 $$;
 
 COMMENT ON FUNCTION pgb_session.replay(p_session_id UUID, p_ts TIMESTAMPTZ) IS
-    'Rewind a session to a snapshot at or before p_ts. Parameters: p_session_id - session ID; p_ts - target timestamp. Example usage: SELECT pgb_session.replay(:session_id, ''2025-08-04T15:30:00Z''::timestamptz); Returns: void.';
+    'Rewind a session to a snapshot at or before p_ts. Raises SQLSTATE PGBSN if the session does not exist and PGBNS if no snapshot is found. Parameters: p_session_id - session ID; p_ts - target timestamp. Example usage: SELECT pgb_session.replay(:session_id, ''2025-08-04T15:30:00Z''::timestamptz); Returns: void.';
 
 CREATE OR REPLACE FUNCTION pgb_session.close(p_session_id UUID)
 RETURNS VOID
@@ -161,4 +161,4 @@ END;
 $$;
 
 COMMENT ON FUNCTION pgb_session.close(p_session_id UUID) IS
-    'Close a session and remove all associated data. Parameters: p_session_id - session ID. Returns: void.';
+    'Close a session and remove all associated data. Raises SQLSTATE PGBSN if the session does not exist. Parameters: p_session_id - session ID. Returns: void.';

--- a/sql/60_pgb_session_open.sql
+++ b/sql/60_pgb_session_open.sql
@@ -24,4 +24,4 @@ END;
 $$;
 
 COMMENT ON FUNCTION pgb_session.open(p_url TEXT) IS
-    'Open a new session. Parameters: p_url - initial URL. Returns: session UUID.';
+    'Open a new session. Raises SQLSTATE PGBUV if the initial URL is invalid. Parameters: p_url - initial URL. Returns: session UUID.';

--- a/sql/60_pgb_session_reload.sql
+++ b/sql/60_pgb_session_reload.sql
@@ -20,4 +20,4 @@ END;
 $$;
 
 COMMENT ON FUNCTION pgb_session.reload(p_session_id UUID) IS
-    'Record a reload event. Parameters: p_session_id - session ID. Returns: void.';
+    'Record a reload event. Raises SQLSTATE PGBSN if the session does not exist. Parameters: p_session_id - session ID. Returns: void.';

--- a/sql/60_pgb_session_validate_url.sql
+++ b/sql/60_pgb_session_validate_url.sql
@@ -21,5 +21,5 @@ END;
 $$;
 
 COMMENT ON FUNCTION pgb_session.validate_url(p_url TEXT) IS
-    'Validate a URL ensuring it is not empty, trimmed, and uses an allowed scheme with a valid host/path. Returns the trimmed URL.';
+    'Validate a URL ensuring it is not empty, trimmed, and uses an allowed scheme with a valid host/path. Raises SQLSTATE PGBUV if the URL is empty or invalid. Returns the trimmed URL.';
 


### PR DESCRIPTION
## Summary
- Document custom SQLSTATE codes in new README section
- Reference codes in pgb_session function comments
- Remind contributors to update the Error Codes list when adding new codes

## Testing
- `./tests/run_regress.sh` *(fails: /usr/lib/postgresql/16/bin/pg_regress: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689f4c48983483289fc7883f75576798