### PR TITLE
Use history identity in session test

### DIFF
--- a/tests/test_pgb_session.sql
+++ b/tests/test_pgb_session.sql
@@ -41,8 +41,8 @@ BEGIN
     SET current_url = 'pgb://local/other', state = '{"foo":"bar"}'
     WHERE id = sid;
     PERFORM pg_sleep(0.001);
-    INSERT INTO pgb_session.history(session_id, n, url, ts)
-    VALUES (sid, 2, 'pgb://local/other', clock_timestamp());
+    INSERT INTO pgb_session.history(session_id, url, ts)
+    VALUES (sid, 'pgb://local/other', clock_timestamp());
 
     -- Replay to snapshot
     PERFORM pgb_session.replay(sid, snap_ts);


### PR DESCRIPTION
## Summary
- rely on pgb_session.history identity column instead of hardcoded numbers in tests
- keep assertions verifying sequential history numbering

## Testing
- `sudo -u postgres env PGHOST=/var/run/postgresql tests/run.sh`
- `sudo -u postgres env PGHOST=/var/run/postgresql PG_REGRESS=/usr/lib/postgresql/16/lib/pgxs/src/test/regress/pg_regress tests/run_regress.sh` *(fails: 3 of 7 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_689f4c49868c8328b03914906b960d7f