### PR TITLE
Enforce lowercase session URL schemes

### DIFF
--- a/sql/60_pgb_session.sql
+++ b/sql/60_pgb_session.sql
@@ -3,7 +3,7 @@ CREATE SCHEMA IF NOT EXISTS pgb_session;
 CREATE TABLE IF NOT EXISTS pgb_session.session (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
-    current_url TEXT NOT NULL CONSTRAINT session_current_url_check CHECK (current_url ~* '^(pgb|https?)://'),
+    current_url TEXT NOT NULL CONSTRAINT session_current_url_check CHECK (current_url ~ '^(pgb|https?)://'),
     state JSONB NOT NULL DEFAULT '{}'::jsonb,
     focus UUID
 );

--- a/sql/61_add_session_current_url_check.sql
+++ b/sql/61_add_session_current_url_check.sql
@@ -1,5 +1,13 @@
 DO $$
 BEGIN
+    BEGIN
+        ALTER TABLE pgb_session.session
+            DROP CONSTRAINT IF EXISTS session_current_url_check;
+    EXCEPTION
+        WHEN undefined_table THEN
+            RETURN;
+    END;
+
     ALTER TABLE pgb_session.session
         ADD CONSTRAINT session_current_url_check
         CHECK (current_url ~ '^(pgb|https?)://');

--- a/tests/expected/replay.out
+++ b/tests/expected/replay.out
@@ -8,7 +8,7 @@ psql:../../sql/60_pgb_session.sql:1: NOTICE:  schema "pgb_session" already exist
 CREATE TABLE IF NOT EXISTS pgb_session.session (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
-    current_url TEXT NOT NULL CONSTRAINT session_current_url_check CHECK (current_url ~* '^(pgb|https?)://'),
+    current_url TEXT NOT NULL CONSTRAINT session_current_url_check CHECK (current_url ~ '^(pgb|https?)://'),
     state JSONB NOT NULL DEFAULT '{}'::jsonb,
     focus UUID
 );

--- a/tests/expected/session.out
+++ b/tests/expected/session.out
@@ -6,7 +6,7 @@ CREATE SCHEMA IF NOT EXISTS pgb_session;
 CREATE TABLE IF NOT EXISTS pgb_session.session (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
-    current_url TEXT NOT NULL CONSTRAINT session_current_url_check CHECK (current_url ~* '^(pgb|https?)://'),
+    current_url TEXT NOT NULL CONSTRAINT session_current_url_check CHECK (current_url ~ '^(pgb|https?)://'),
     state JSONB NOT NULL DEFAULT '{}'::jsonb,
     focus UUID
 );


### PR DESCRIPTION
## Summary
- make the session current_url constraint use a case-sensitive regex so only lowercase schemes are accepted
- update the upgrade script to drop and recreate the constraint so existing installs pick up the stricter check
- refresh expected test outputs to match the new constraint definition

## Testing
- not run (requires external Postgres instance)


------
https://chatgpt.com/codex/tasks/task_e_68d6a680aa388328a120a275586c4e89